### PR TITLE
Add MkDocs and API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ target/
 
 # MkDocs
 /site
+/docs/api

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "lint - check style with flake8"
 	@echo "test - run tests quickly with the default Python"
 	@echo "coverage - check code coverage quickly with the default Python"
-	@echo "docs - generate API HTML documentation using pdoc"
+	@echo "docs - generate local API HTML documentation using MkDocs"
 	@echo "release - package and upload a release"
 	@echo "dist - package"
 	@echo "install - install the package to the active Python's site-packages"
@@ -30,6 +30,7 @@ clean-build:
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
+	rm -rf docs/api
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -f {} +
 
@@ -57,10 +58,8 @@ coverage:
 	$(BROWSER) htmlcov/index.html
 
 docs:
-	export PYTHONPATH='.'
-	pdoc --html --html-dir docs/api --overwrite --only-pypath --external-links cpc.geogrids
-	mv -f docs/api/cpc.geogrids/* docs/api
-	rm -rf docs/api/cpc.geogrids
+	rm -rf docs/api
+	docs/make_docs.py cpc.geogrids
 
 release: clean
 	python setup.py sdist upload

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help:
 	@echo "test - run tests quickly with the default Python"
 	@echo "coverage - check code coverage quickly with the default Python"
 	@echo "docs - generate local API HTML documentation using MkDocs"
+	@echo "github-docs - generate API HTML documentation on GitHub.io using MkDocs"
 	@echo "release - package and upload a release"
 	@echo "dist - package"
 	@echo "install - install the package to the active Python's site-packages"
@@ -60,6 +61,9 @@ coverage:
 docs:
 	rm -rf docs/api
 	docs/make_docs.py cpc.geogrids
+
+github-docs:
+	mkdocs gh-deploy --clean
 
 release: clean
 	python setup.py sdist upload

--- a/cpc/geogrids/definition.py
+++ b/cpc/geogrids/definition.py
@@ -78,8 +78,7 @@ class GeoGrid:
     A GeoGrid object can either be created by providing the name of the grid, or by providing the
     other attributes listed below
 
-    Attributes
-    ----------
+    #### Attributes
 
     - name - *str* - name of the grid
     - ll_corner - *tuple of floats* - lower-left corner of the grid, formatted as (lat, lon)
@@ -150,18 +149,15 @@ class GeoGrid:
         """
         Determines if the specified data fits this GeoGrid
 
-        Parameters
-        ----------
+        #### Parameters
 
         - data - *array_like* - data to verify
 
-        Returns
-        -------
+        #### Returns
 
         - *boolean* - whether the data fits this GeoGrid
 
-        Exceptions
-        ----------
+        #### Exceptions
 
         - *GeoGridError* - raised if data is not a valid NumPy array
         """
@@ -179,13 +175,11 @@ class GeoGrid:
         Returns the index of the 1-dimensional array corresponding to this GeoGrid, given the lat and lon values. The
         lat/lon value pair must match the location of a gridpoint in this GeoGrid, otherwise None will be returned.
 
-        Parameters
-        ----------
+        #### Parameters
 
         - latlons - *tuple of floats* or *list of tuples of floats* - lat/lon of grid point(s)
 
-        Returns
-        -------
+        #### Returns
 
         - *int* or *None* - array index containing the given gridpoint(s) index(es), or -1 if no gridpoint matches the
         given lat/lon value

--- a/cpc/geogrids/manipulation.py
+++ b/cpc/geogrids/manipulation.py
@@ -21,9 +21,9 @@ def interpolate(orig_data, orig_grid, new_grid):
     Parameters
     ----------
 
-    - orig_data - *array_like8 - array of original data
+    - orig_data - *array_like* - array of original data
     - orig_grid - *GeoGrid* - original GeoGrid
-    - new_grid - *GeoGrid - new GeoGrid
+    - new_grid - *GeoGrid* - new GeoGrid
 
     Returns
     -------

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,25 @@
+h1 {
+    font-size: 2em;
+}
+h1, h2 {
+    border-bottom: thin solid #DDD;
+}
+pre, code {
+    font-size: 1em;
+}
+span.function {
+    color: black;
+    font-family: monospace;
+    font-size: 1.1em;
+    border: none;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap important;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+}
+blockquote {
+    border-left: 2px solid #DDD;
+    padding-left: 10px;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,3 +54,53 @@ For example:
 from cpc.geogrids.definition import GeoGrid
 grid = GeoGrid(ll_corner=(20, 30), ur_corner=(60, 90), res=2)
 ```
+
+How do I manipulate data on GeoGrids?
+-------------------------------------
+
+The `cpc.geogrids` packages comes with several functions to manipulate data residing on GeoGrids, such as interpolating between GeoGrids, smoothing GeoGrids, and filling in data points near the border of a mask (eg. coastal values). These functions are documented below.
+
+### Interpolating data
+
+The `interpolate()` function can interpolate an array of data from one GeoGrid to another.
+
+    interpolate(orig_data, orig_grid, new_grid)
+
+    Interpolates data from one GeoGrid to another.
+
+    Parameters
+    ----------
+
+    - orig_data - *array_like* - array of original data
+    - orig_grid - *GeoGrid* - original GeoGrid
+    - new_grid - *GeoGrid* - new GeoGrid
+
+    Returns
+    -------
+
+    - new_data - *array_like* - a data array on the desired GeoGrid.
+
+    Examples
+    --------
+
+    Interpolate gridded temperature obs from 2 degrees (CONUS) to 1 degree global
+
+```python
+#!/usr/bin/env python
+>>> # Import packages
+>>> import numpy as np
+>>> from cpc.geogrids.definition import GeoGrid
+>>> from cpc.geogrids.manipulation import interpolate
+>>> # Create original and new GeoGrids
+>>> orig_grid = GeoGrid('1deg-global')
+>>> new_grid = GeoGrid('2deg-global')
+>>> # Generate random data on the original GeoGrid
+>>> A = np.random.rand(orig_grid.num_y, orig_grid.num_x)
+>>> # Interpolate data to the new GeoGrid
+>>> B = interpolate(A, orig_grid, new_grid)
+>>> # Print shapes of data before and after
+>>> print(A.shape)
+(181, 360)
+>>> print(B.shape)
+(91, 180)
+```

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+import os, sys
+import re
+import subprocess
+import pkgutil
+
+
+def list_submodules(submodules_list, package):
+    """
+    Lists all the submodules in the given package.
+
+    Nothing is returned from this function; it will instead append the names (as strings) of all
+    submodules found in the given package to `submodules_list`.
+
+    ### Parameters
+
+    - submodules_list (list): list to append module names to
+    - package (module): package to find submodules in
+    """
+    for loader, module_name, is_pkg in pkgutil.walk_packages(package.__path__, package.__name__+'.'):
+        submodules_list.append(module_name)
+        module_name = __import__(module_name, fromlist='dummylist')
+        if is_pkg and module_name != package.__name__:
+            list_submodules(submodules_list, module_name)
+
+
+def write_module_api(module_name, parent_dir='.', out_file=None, remove_top_level=True,
+                     customize_formatting=False):
+    """
+    Writes API documentation for a given module to a Markdown file.
+
+    The name of the Markdown file is determined by the hierarchy given in the module name (using
+    dots). The top-level package name is removed from the module name (if `remove_top_level=True`),
+    and every dot is converted to a forward slash, which results in a path to a file (once '.md'
+    is appended).
+
+    For example, API documentation for the module `sound.effects.echo` would be written to
+    `./effects/echo.md` (or `./sound/effects/echo.md` if `remove_top_level=False`).
+
+    ### Parameters
+
+    - module_name (*string*): name of module to write API documentation for
+    - parent_dir (*string*, default='.'): parent directory to write API documentation to
+    - out_file (*string*, default=None): Markdown file to write to (if None, determine
+      automatically using the name of the module)
+    - remove_top_level (*boolean*, default=True): remove the top level of the module name when
+      determining the out_file
+    - customize_formatting (*boolean*, default=False): customize the default Markdown written by
+      the `pydoc-markdown` module
+    """
+    output = subprocess.check_output('pydoc-markdown {}'.format(module_name), shell=True).decode(
+        'ascii')
+    # Customize formatting (optional)
+    if customize_formatting:
+        # Make functions/classes non-inline code level 3 headings instead of inline code level 5
+        # headings
+        regex = re.compile(r'^##### `(__.*)`', flags=re.MULTILINE)  # dunder functions
+        replacement = '### <span class="function">\\\\\g<1></span>'
+        output = regex.sub(replacement, output)
+        regex = re.compile(r'^##### `(.*)`', flags=re.MULTILINE)  # non-dunder functions
+        replacement = '### <span class="function">\g<1></span>'
+        output = regex.sub(replacement, output)
+
+    # Write output to file
+    if out_file is None:
+        if remove_top_level:
+            out_file_full = re.sub('^{}\.'.format(main_package_name), '', module_name) + '.md'
+        else:
+            out_file_full = module_name + '.md'
+        out_file_full = parent_dir + '/' + out_file_full
+    out_dir = os.path.dirname(out_file_full)
+    out_file = os.path.basename(out_file_full)
+    print('Writing output to {}/{}...'.format(out_dir, out_file))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(out_dir + '/' + out_file, 'w') as f:
+        f.write(output)
+
+# Get command-line args
+if len(sys.argv) != 2:
+    print('Usage: {} [PACKAGE-NAME]'.format(os.path.basename(__file__)))
+    sys.exit(1)
+else:
+    main_package_name = sys.argv[1]
+
+# Try importing the package to find submodules in
+try:
+    package = __import__(main_package_name, fromlist='dummylist')
+except ImportError:
+    print('Package {} not found...'.format(main_package_name))
+    sys.exit(1)
+
+# Initialize list of modules
+all_submodules = []
+list_submodules(all_submodules, package)
+
+for submodule_name in all_submodules:
+    write_module_api(submodule_name, parent_dir='api', customize_formatting=True)

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -76,11 +76,16 @@ def write_module_api(module_name, parent_dir='.', out_file=None, remove_top_leve
         f.write(output)
 
 # Get command-line args
-if len(sys.argv) != 2:
+if len(sys.argv) < 2:
     print('Usage: {} [PACKAGE-NAME]'.format(os.path.basename(__file__)))
     sys.exit(1)
 else:
     main_package_name = sys.argv[1]
+
+try:
+    parent_dir = sys.argv[2]
+except IndexError:
+    parent_dir = 'docs/api'
 
 # Try importing the package to find submodules in
 try:
@@ -94,4 +99,4 @@ all_submodules = []
 list_submodules(all_submodules, package)
 
 for submodule_name in all_submodules:
-    write_module_api(submodule_name, parent_dir='api', customize_formatting=True)
+    write_module_api(submodule_name, parent_dir=parent_dir, customize_formatting=True)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,3 +3,9 @@ repo_url: https://github.com/noaa-nws-cpc/cpc.geogrids
 site_description: CPC geospatial grids (grid definitions, interpolation, etc.)
 site_author: Mike Charles
 theme: readthedocs
+extra_css: [extra.css]
+markdown_extensions:
+  - admonition
+  - def_list
+  - toc:
+      permalink: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pdoc
 cryptography
 PyYAML
 mkdocs
-
+pydoc-markdown


### PR DESCRIPTION
Use MkDocs to generate HTML documentation from static Markdown files. Also adds a script `make_docs.py` that generates Markdown files from docstring documentation in all submodules of a given package. These files also get picked up and converted by MkDocs.